### PR TITLE
fix: Removed delete for CustomFields.GELF

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,8 +74,6 @@ function gelfAppender(layout, config, levels) {
     const firstData = data[0];
     if (firstData) {
       if (!firstData.GELF) return; // identify with GELF field defined
-      // Remove the GELF key, some gelf supported logging systems drop the message with it
-      delete firstData.GELF;
       Object.keys(firstData).forEach((key) => {
         // skip _id field for graylog2, skip keys not starts with UNDERSCORE
         if (key.match(/^_/) && key !== '_id') {


### PR DESCRIPTION
When using log4js with the GELF-Appender like this, only the first message is sent correctly. GELF_DATA.GELF is removed after the first call. 

```JS
const GELF_DATA = {
  GELF: true,
  _userId: "someID"
  _customerId: "someOtherId"
};

//GELF_DATA.GELF was removed here
logger.info(GELF_DATA, "Requested resource");

if(accessOk) {
  logger.info(GELF_DATA, "Resource access OK");
}else {
  logger.warn(GELF_DATA, "Resource access not OK");
}
```

Field is not used later as all fields not starting with underscore are removed anyway. 
The fix keeps the input-object unchanged. And allows this kind of usage.
